### PR TITLE
Update setColumnNotNullable method to drop constraint if already exists

### DIFF
--- a/src/Doctrine/Migration.php
+++ b/src/Doctrine/Migration.php
@@ -139,6 +139,10 @@ abstract class Migration extends AbstractMigration
     protected function setColumnNotNullable(string $table, string $name): void
     {
         $constraintName = sprintf('chk_null_%s_%s', $table, $name);
+        $this->addUnsafeSql(sprintf('ALTER TABLE %s DROP CONSTRAINT IF EXISTS "%s"',
+            $table,
+            $constraintName,
+        ));
         $this->addUnsafeSql(sprintf('ALTER TABLE %s ADD CONSTRAINT "%s" CHECK (%s IS NOT NULL) NOT VALID',
             $table,
             $constraintName,

--- a/tests/Database/Doctrine/Migrations/MigrationTest.php
+++ b/tests/Database/Doctrine/Migrations/MigrationTest.php
@@ -213,6 +213,7 @@ final class MigrationTest extends TestCase
         $this->migration->setColumnNotNullable('signer', 'email');
 
         $this->assertSql([
+            'ALTER TABLE signer DROP CONSTRAINT IF EXISTS "chk_null_signer_email"',
             'ALTER TABLE signer ADD CONSTRAINT "chk_null_signer_email" CHECK (email IS NOT NULL) NOT VALID',
             "SET statement_timeout TO '0'",
             'ALTER TABLE signer VALIDATE CONSTRAINT "chk_null_signer_email"',


### PR DESCRIPTION
When setColumnNotNullable execution timed out, the retry mechanism is blocked because the constraint is already created.

We should drop the constraint before being able to add it again.