### PR TITLE
Update addIndex method to automatically execute an analyze to refresh…

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ $this->commentOnColumn(table: 'address', name: 'name', comment: null)
 
 <details><summary>Add index</summary>
 
+> Note: Adding an index on a table will execute an "analyze" on all columns of the table to update statistics
+
 ```php
 $this->addIndex(name: 'idx_contact_email', table: 'contact', columns: ['email'], unique: false, usingMethod: 'GIN', where: 'country = "France"')
 ```

--- a/src/Doctrine/Migration.php
+++ b/src/Doctrine/Migration.php
@@ -37,7 +37,7 @@ abstract class Migration extends AbstractMigration
         $this->throwIrreversibleMigrationException();
     }
 
-    protected function addUnsafeSql(string $sql, array $params = [], array $types = [], int $statementTimeout = null): void
+    protected function addUnsafeSql(string $sql, array $params = [], array $types = [], ?int $statementTimeout = null): void
     {
         if (null !== $statementTimeout) {
             parent::addSql("SET statement_timeout TO '{$statementTimeout}s'");
@@ -76,6 +76,7 @@ abstract class Migration extends AbstractMigration
             $where ? " WHERE $where" : '',
         ));
         $this->addUnsafeSql("SET lock_timeout TO '3s'");
+        $this->addUnsafeSql(sprintf('ANALYZE %s', $table));
     }
 
     protected function dropIndex(string $name): void
@@ -88,7 +89,7 @@ abstract class Migration extends AbstractMigration
         $this->addUnsafeSql(sprintf('ALTER INDEX %s RENAME TO %s', $from, $to));
     }
 
-    protected function addColumn(string $table, string $name, string $type, string $defaultValue = null, bool $nullable = true): void
+    protected function addColumn(string $table, string $name, string $type, ?string $defaultValue = null, bool $nullable = true): void
     {
         if (null !== $defaultValue && u($defaultValue)->trim()->ignoreCase()->equalsTo('NULL')) {
             throw new AbortMigration(__METHOD__.' requires the usage of null PHP value instead of string one as default value.');
@@ -192,7 +193,7 @@ abstract class Migration extends AbstractMigration
      * @param string|null $options Can be used to add things like:
      *                             [ ON DELETE|ON UPDATE referential_action ] [ DEFERRABLE|NOT DEFERRABLE ] [ INITIALLY DEFERRED|INITIALLY IMMEDIATE ]
      */
-    protected function addForeignKey(string $table, string $name, string $column, string $referenceTable, string $referenceColumn, string $options = null): void
+    protected function addForeignKey(string $table, string $name, string $column, string $referenceTable, string $referenceColumn, ?string $options = null): void
     {
         $this->addUnsafeSql(sprintf('ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s(%s)%s NOT VALID',
             $table,

--- a/tests/Database/Doctrine/Migrations/MigrationTest.php
+++ b/tests/Database/Doctrine/Migrations/MigrationTest.php
@@ -71,6 +71,7 @@ final class MigrationTest extends TestCase
             'SET lock_timeout TO \'0\'',
             'CREATE INDEX CONCURRENTLY idx_approver_email ON approver (email)',
             'SET lock_timeout TO \'3s\'',
+            'ANALYZE approver',
         ]);
     }
 
@@ -83,6 +84,7 @@ final class MigrationTest extends TestCase
             'SET lock_timeout TO \'0\'',
             'CREATE INDEX CONCURRENTLY idx_approver_first_name_email ON approver (first_name,email)',
             'SET lock_timeout TO \'3s\'',
+            'ANALYZE approver',
         ]);
     }
 
@@ -95,6 +97,7 @@ final class MigrationTest extends TestCase
             'SET lock_timeout TO \'0\'',
             'CREATE UNIQUE INDEX CONCURRENTLY uq_signer_email ON signer (email)',
             'SET lock_timeout TO \'3s\'',
+            'ANALYZE signer',
         ]);
     }
 
@@ -107,6 +110,7 @@ final class MigrationTest extends TestCase
             'SET lock_timeout TO \'0\'',
             'CREATE INDEX CONCURRENTLY idx_signer_email ON signer USING GIN(email)',
             'SET lock_timeout TO \'3s\'',
+            'ANALYZE signer',
         ]);
     }
 
@@ -119,6 +123,7 @@ final class MigrationTest extends TestCase
             'SET lock_timeout TO \'0\'',
             'CREATE INDEX CONCURRENTLY idx_signer_email ON signer (email) WHERE name = "foo"',
             'SET lock_timeout TO \'3s\'',
+            'ANALYZE signer',
         ]);
     }
 
@@ -331,7 +336,7 @@ class TestMigration extends Migration
         throw new \Exception('Unused for this test');
     }
 
-    public function addUnsafeSql(string $sql, array $params = [], array $types = [], int $statementTimeout = null): void
+    public function addUnsafeSql(string $sql, array $params = [], array $types = [], ?int $statementTimeout = null): void
     {
         parent::addUnsafeSql($sql, $params, $types, $statementTimeout);
     }
@@ -351,7 +356,7 @@ class TestMigration extends Migration
         parent::renameIndex($from, $to);
     }
 
-    public function addColumn(string $table, string $name, string $type, string $defaultValue = null, bool $nullable = true): void
+    public function addColumn(string $table, string $name, string $type, ?string $defaultValue = null, bool $nullable = true): void
     {
         parent::addColumn($table, $name, $type, $defaultValue, $nullable);
     }
@@ -396,7 +401,7 @@ class TestMigration extends Migration
         parent::createTable($table, $columnDefinitions);
     }
 
-    public function addForeignKey(string $table, string $name, string $column, string $referenceTable, string $referenceColumn, string $options = null): void
+    public function addForeignKey(string $table, string $name, string $column, string $referenceTable, string $referenceColumn, ?string $options = null): void
     {
         parent::addForeignKey($table, $name, $column, $referenceTable, $referenceColumn, $options);
     }


### PR DESCRIPTION
💁 What?

Update addIndex method to execute a ANALYZE after the index creation to refresh table statistics allowing PG to improve its usage of the index.

🏗️ How to do it?

Update the safe-migration package by adding the ANALYSE statement on index creation

✅ Acceptance Criteria

Table statistics are up-to-date after a index creation

📔 Resources

PostgresQL ANALYZE documentation:

https://www.postgresql.org/docs/current/sql-analyze.html